### PR TITLE
Explicit cast to String, otherwise build errors on atmelavrmega

### DIFF
--- a/DFRobot_DF1101S.cpp
+++ b/DFRobot_DF1101S.cpp
@@ -56,7 +56,7 @@ DFRobot_DF1101S::ePlayMode_t DFRobot_DF1101S::getPlayMode(){
    cmd = pack("PLAYMODE","?");
    writeATCommand(cmd.str,cmd.length);
    String str = readAck(13);
-   playMode = str[10];
+   playMode = String(str[10]);
    //Serial.println(str);
    if(str[11] == '\r'  && str[12] == '\n')
      return (ePlayMode_t)atoi(playMode.c_str());


### PR DESCRIPTION
Using PlatformIO and the newer AVR Mega platforms, the library doesn't compile:

```
.platformio/packages/framework-arduino-megaavr/cores/arduino/api/String.h:98:11: note:   conversion of argument 1 would be ill-formed:
.pio/libdeps/arduino_nano_every/DFRobot_DF1101S/DFRobot_DF1101S.cpp:59:21: error: conversion from 'char' to 'const arduino::String' is ambiguous
    playMode = str[10];
```
Using an explicit cast (initialize a String with the character), it works.